### PR TITLE
Use passed specSwaggerName when provided

### DIFF
--- a/apidetails.html
+++ b/apidetails.html
@@ -144,6 +144,7 @@
     $("#swagger-ui-container").parent().remove();
 
     var service_id = Number(extractServiceID())
+    var specSystemName = extractSystemName()
     var url = 'apis.json'
 //4a.function creation
 // var slingshot = function (url, tplId, anchor) {
@@ -153,8 +154,13 @@
       APIS=data.apis
 
       console.log("SERVICE_ID",service_id)
+      console.log("SPEC_SYSTEM_NAME", specSystemName)
 
-      API = filterArraybyThreescaleServiceId(APIS,service_id)
+      API = filterArraybyThreescaleServiceIdAndSystemName(APIS,service_id,specSystemName);
+
+      if(API.length==0){
+        API = filterArraybyThreescaleServiceId(APIS,service_id);
+      }
 
       if(API.length ==0){
         var template = $("#errorTpl").html();
@@ -167,7 +173,11 @@
         var stone = Handlebars.compile(template)(API[0]);
         $("#content").html(stone);
 
-		var specSystemName = API[0]['X-3scale']['swagger_system_name'];
+        if (!specSystemName || 0 === specSystemName.length){
+		      specSystemName = API[0]['X-3scale']['swagger_system_name'];
+          console.log("No specSystemName passed, use API: " + specSystemName);
+        }
+
       	var domId = "swagger-ui-container-" + specSystemName;
       	loadSwagger(specSystemName, domId);
       }
@@ -179,9 +189,25 @@
     return _.filter(arr, function(obj){ if(typeof obj["X-3scale"] != "undefined"){return obj["X-3scale"].service_id === service_id}});
   }
 
+  function filterArraybyThreescaleServiceIdAndSystemName(arr,service_id,specSystemName){
+    return _.filter(arr, function(obj){ if(typeof obj["X-3scale"] != "undefined"){return obj["X-3scale"].service_id === service_id  && obj["X-3scale"].swagger_system_name === specSystemName}});
+  }
+
+
   function extractServiceID(){
     var url = window.location.href
     var captured = /service_id=([^&]+)/.exec(url)[1]; // Value is in [1]
+    return captured;
+  }
+
+  function extractSystemName(){
+    var url = window.location.href
+    var captured;
+    try {
+      captured = /swagger_system_name=([^&]+)/.exec(url)[1]; // Value is in [1]
+    } catch(err) {
+      console.log("The swagger_system_name parameter was not passed");
+    }
     return captured;
   }
 

--- a/apilist.html
+++ b/apilist.html
@@ -82,7 +82,7 @@
 <script id="apiListTpl" type="text/template">
   <div id="apilist">
     {{#each apis}}
-     <a href="/apidetails?service_id={{X-3scale.service_id}}">
+     <a href="/apidetails?service_id={{X-3scale.service_id}}&amp;swagger_system_name={{X-3scale.swagger_system_name}}">
         <div class = "panel panel-default">
           <div class="panel-body">
             <div class= "col-md-2">  <!-- Comment this div if you don't want to show images-->


### PR DESCRIPTION
This PR changes the behavior of the apidetails page so that it uses the swagger spec specified in apis.json rather then using the swagger spec for the first matching service.

With the current page, if you have one service but multiple activedocs that map to that service it always uses the swagger spec from the first entry in apis.json. I have a customer where they have one endpoint but the services under that endpoint each have their own swagger specification. While it's certainly possible to define each one as a separate service in 3scale, this can be a bit painful if there is many of them.