### PR TITLE
OpenAPI Specification 3 support

### DIFF
--- a/doc/activedocs.md
+++ b/doc/activedocs.md
@@ -22,7 +22,7 @@ The API list is generated from the service name and description, separated by a 
 ## Prerequesites
 
 * 3scale account with Developer Portal
-* an OpenAPI Specification, version 2.0 (3scale ActiveDocs) for each service
+* an OpenAPI Specification, version 2.0 or 3.0 (3scale ActiveDocs) for each service
 
 Currently, this module expects that Services and ActiveDocs objects will have
 the same system_name (in order to match a service with an ActiveDocs).

--- a/documentation.html
+++ b/documentation.html
@@ -1,7 +1,11 @@
-{% cdn_asset /swagger-ui/2.2.10/swagger-ui.js %}
-{% cdn_asset /swagger-ui/2.2.10/swagger-ui.css %}
+{% content_for javascripts %}
+    {{ 'active_docs.js' | javascript_include_tag }}
+{% endcontent_for %}
 
-{% include 'shared/swagger_ui' %}
+<div class="swagger-section">
+  <div id="message-bar" class="swagger-ui-wrap">&nbsp;</div>
+  <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</div>
 
 <div class="api-list-container" style="display: none;">
   <h1>API Catalog</h1>
@@ -29,8 +33,7 @@
     if (searchParams.has("api")) {
       var api = searchParams.get("api");
       $(".api-list-container").css("display", "none");
-      window.swaggerUi.options['url'] = services[api].url;
-      window.swaggerUi.load();
+      SwaggerUI({ url: services[api].url, dom_id: "#swagger-ui-container" });
     } else {
       $(".api-list-container").css("display", "block");
       var system_names = Object.keys(services).sort();


### PR DESCRIPTION
As explained in the [official documentation](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.8/html/providing_apis_in_the_developer_portal/using-oas30), some changes are needed to support OAS3.